### PR TITLE
change label code in consistent with go-grpc-promethues

### DIFF
--- a/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
@@ -2,17 +2,17 @@
 
 package me.dinowernli.grpc.prometheus;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 import io.grpc.MethodDescriptor;
 import io.grpc.Status.Code;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.SimpleCollector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Prometheus metric definitions used for client-side monitoring of grpc services.
@@ -29,7 +29,7 @@ class ClientMetrics {
       .namespace("grpc")
       .subsystem("client")
       .name("completed")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "code")
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "grpc_code")
       .help("Total number of RPCs completed on the client, regardless of success or failure.");
 
   private static final Histogram.Builder completedLatencySecondsBuilder =

--- a/src/main/java/me/dinowernli/grpc/prometheus/ServerMetrics.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/ServerMetrics.java
@@ -2,17 +2,17 @@
 
 package me.dinowernli.grpc.prometheus;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 import io.grpc.MethodDescriptor;
 import io.grpc.Status.Code;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.SimpleCollector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Prometheus metric definitions used for server-side monitoring of grpc services.
@@ -32,7 +32,7 @@ class ServerMetrics {
       .namespace("grpc")
       .subsystem("server")
       .name("handled_total")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "code")
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "grpc_code")
       .help("Total number of RPCs completed on the server, regardless of success or failure.");
 
   private static final Histogram.Builder serverHandledLatencySecondsBuilder =


### PR DESCRIPTION
Change label `code` to `grpc_code`.  Reference https://github.com/grpc-ecosystem/go-grpc-prometheus#labels.

By the way, label values of `grpc_type`, `code` is  in different formants, too. But it's hard to say which one is better. 