### PR TITLE
Improve performance of MonitoringInterceptors

### DIFF
--- a/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
@@ -130,10 +130,10 @@ class ClientMetrics {
       }
     }
 
-    /** Creates a {@link ClientMetrics} for the supplied method. */
-    <R, S> ClientMetrics createMetricsForMethod(MethodDescriptor<R, S> methodDescriptor) {
+    /** Creates a {@link ClientMetrics} for the supplied gRPC method. */
+    ClientMetrics createMetricsForMethod(GrpcMethod grpcMethod) {
       return new ClientMetrics(
-          GrpcMethod.of(methodDescriptor),
+          grpcMethod,
           rpcStarted,
           rpcCompleted,
           streamMessagesReceived,

--- a/src/main/java/me/dinowernli/grpc/prometheus/MonitoringClientInterceptor.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/MonitoringClientInterceptor.java
@@ -33,11 +33,12 @@ public class MonitoringClientInterceptor implements ClientInterceptor {
   @Override
   public <R, S> ClientCall<R, S> interceptCall(
       MethodDescriptor<R, S> methodDescriptor, CallOptions callOptions, Channel channel) {
-    ClientMetrics metrics = clientMetricsFactory.createMetricsForMethod(methodDescriptor);
+    GrpcMethod grpcMethod = GrpcMethod.of(methodDescriptor);
+    ClientMetrics metrics = clientMetricsFactory.createMetricsForMethod(grpcMethod);
     return new MonitoringClientCall<>(
         channel.newCall(methodDescriptor, callOptions),
         metrics,
-        GrpcMethod.of(methodDescriptor),
+        grpcMethod,
         configuration,
         clock);
   }

--- a/src/main/java/me/dinowernli/grpc/prometheus/MonitoringServerInterceptor.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/MonitoringServerInterceptor.java
@@ -33,12 +33,12 @@ public class MonitoringServerInterceptor implements ServerInterceptor {
       ServerCall<R, S> call,
       Metadata requestHeaders,
       ServerCallHandler<R, S> next) {
-    MethodDescriptor<R, S> method = call.getMethodDescriptor();
-    ServerMetrics metrics = serverMetricsFactory.createMetricsForMethod(method);
-    GrpcMethod grpcMethod = GrpcMethod.of(method);
+    MethodDescriptor<R, S> methodDescriptor = call.getMethodDescriptor();
+    GrpcMethod grpcMethod = GrpcMethod.of(methodDescriptor);
+    ServerMetrics metrics = serverMetricsFactory.createMetricsForMethod(grpcMethod);
     ServerCall<R,S> monitoringCall = new MonitoringServerCall(call, clock, grpcMethod, metrics, configuration);
     return new MonitoringServerCallListener<>(
-        next.startCall(monitoringCall, requestHeaders), metrics, GrpcMethod.of(method));
+        next.startCall(monitoringCall, requestHeaders), metrics, gprcMethod);
   }
 
 }

--- a/src/main/java/me/dinowernli/grpc/prometheus/ServerMetrics.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/ServerMetrics.java
@@ -134,10 +134,10 @@ class ServerMetrics {
       }
     }
 
-    /** Creates a {@link ServerMetrics} for the supplied method. */
-    <R, S> ServerMetrics createMetricsForMethod(MethodDescriptor<R, S> methodDescriptor) {
+    /** Creates a {@link ServerMetrics} for the supplied gRPC method. */
+    ServerMetrics createMetricsForMethod(GrpcMethod grpcMethod) {
       return new ServerMetrics(
-          GrpcMethod.of(methodDescriptor),
+          grpcMethod,
           serverStarted,
           serverHandled,
           serverStreamMessagesReceived,


### PR DESCRIPTION
The current implementation has multiple GrpcMethod.of() calls which are unnecessary. The method in turn calls three String methods (.substring twice, .lastIndexOf once) which add unnecessary overhead which should be avoided when collecting metrics.