### PR TITLE
Add "grpc_code" label for grpc_{client,server}_handled_total

### DIFF
--- a/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/ClientMetrics.java
@@ -29,7 +29,8 @@ class ClientMetrics {
       .namespace("grpc")
       .subsystem("client")
       .name("completed")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "code")
+      // TODO: The "code" label should be deprecated in a future major release. (See also below in recordClientHandled().)
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "code", "grpc_code")
       .help("Total number of RPCs completed on the client, regardless of success or failure.");
 
   private static final Histogram.Builder completedLatencySecondsBuilder =
@@ -82,7 +83,8 @@ class ClientMetrics {
   }
 
   public void recordClientHandled(Code code) {
-    addLabels(rpcCompleted, code.toString()).inc();
+    // TODO: The "code" label should be deprecated in a future major release.
+    addLabels(rpcCompleted, code.toString(), code.toString()).inc();
   }
 
   public void recordStreamMessageSent() {

--- a/src/main/java/me/dinowernli/grpc/prometheus/ServerMetrics.java
+++ b/src/main/java/me/dinowernli/grpc/prometheus/ServerMetrics.java
@@ -32,7 +32,8 @@ class ServerMetrics {
       .namespace("grpc")
       .subsystem("server")
       .name("handled_total")
-      .labelNames("grpc_type", "grpc_service", "grpc_method", "code")
+      // TODO: The "code" label should be deprecated in a future major release. (See also below in recordServerHandled().)
+      .labelNames("grpc_type", "grpc_service", "grpc_method", "code", "grpc_code")
       .help("Total number of RPCs completed on the server, regardless of success or failure.");
 
   private static final Histogram.Builder serverHandledLatencySecondsBuilder =
@@ -86,7 +87,8 @@ class ServerMetrics {
   }
 
   public void recordServerHandled(Code code) {
-    addLabels(serverHandled, code.toString()).inc();
+    // TODO: The "code" label should be deprecated in a future major release.
+    addLabels(serverHandled, code.toString(), code.toString()).inc();
   }
 
   public void recordStreamMessageSent() {


### PR DESCRIPTION
The go-grpc-prometheus and python-grpc-prometheus libraries use the name
"grpc_code" to record the GRPC message code of handled calls.

To avoid breaking compatibility with users that depend on the "code"
label being used, we add a copy of the label under the name "grpc_code".
Future releases should deprecate and remove the "code" label.

This should resolve https://github.com/grpc-ecosystem/java-grpc-prometheus/pull/7 in a non-destructive way.